### PR TITLE
fix: filter interactions by item_id instead of learner_id

### DIFF
--- a/backend/app/routers/interactions.py
+++ b/backend/app/routers/interactions.py
@@ -16,7 +16,7 @@ def _filter_by_item_id(
 ) -> list[InteractionLog]:
     if item_id is None:
         return interactions
-    return [i for i in interactions if i.learner_id == item_id]
+    return [i for i in interactions if i.item_id == item_id]
 
 
 @router.get("/", response_model=list[InteractionModel])

--- a/backend/tests/unit/test_interactions.py
+++ b/backend/tests/unit/test_interactions.py
@@ -24,3 +24,10 @@ def test_filter_returns_interaction_with_matching_ids() -> None:
     result = _filter_by_item_id(interactions, 1)
     assert len(result) == 1
     assert result[0].id == 1
+def test_filter_excludes_interaction_with_different_learner_id() -> None:
+    interactions = [_make_log(id=1, learner_id=2, item_id=1)]
+    result = _filter_by_item_id(interactions, 1)
+    assert len(result) == 1
+    assert result[0].id == 1
+    assert result[0].item_id == 1
+    assert result[0].learner_id == 2


### PR DESCRIPTION


## Summary

- Closes #2 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: <branch-name>` above the PR title.
- [x] I edited the line `- Closes #<issue-number>`.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.
